### PR TITLE
removed clientstream & app hosts from launchdarkly domain

### DIFF
--- a/ads-and-tracking-extended.txt
+++ b/ads-and-tracking-extended.txt
@@ -31474,9 +31474,6 @@
 0.0.0.0 luna.r.lafamo.com
 0.0.0.0 static.lakana.com
 0.0.0.0 activate.lanebryant.com
-0.0.0.0 clientstream.launchdarkly.com
-0.0.0.0 app.intuit.launchdarkly.com
-0.0.0.0 clientstream.intuit.launchdarkly.com
 0.0.0.0 events.intuit.launchdarkly.com
 0.0.0.0 leadbolt.com
 0.0.0.0 api.leadbolt.com

--- a/ads-and-tracking.txt
+++ b/ads-and-tracking.txt
@@ -2730,9 +2730,6 @@
 0.0.0.0 luna.r.lafamo.com
 0.0.0.0 static.lakana.com
 0.0.0.0 activate.lanebryant.com
-0.0.0.0 clientstream.launchdarkly.com
-0.0.0.0 app.intuit.launchdarkly.com
-0.0.0.0 clientstream.intuit.launchdarkly.com
 0.0.0.0 events.intuit.launchdarkly.com
 0.0.0.0 leadbolt.com
 0.0.0.0 www.leadbolt.com

--- a/docs/lists/ads-and-tracking-extended.txt
+++ b/docs/lists/ads-and-tracking-extended.txt
@@ -31474,9 +31474,6 @@
 0.0.0.0 luna.r.lafamo.com
 0.0.0.0 static.lakana.com
 0.0.0.0 activate.lanebryant.com
-0.0.0.0 clientstream.launchdarkly.com
-0.0.0.0 app.intuit.launchdarkly.com
-0.0.0.0 clientstream.intuit.launchdarkly.com
 0.0.0.0 events.intuit.launchdarkly.com
 0.0.0.0 leadbolt.com
 0.0.0.0 api.leadbolt.com

--- a/docs/lists/ads-and-tracking.txt
+++ b/docs/lists/ads-and-tracking.txt
@@ -2730,9 +2730,6 @@
 0.0.0.0 luna.r.lafamo.com
 0.0.0.0 static.lakana.com
 0.0.0.0 activate.lanebryant.com
-0.0.0.0 clientstream.launchdarkly.com
-0.0.0.0 app.intuit.launchdarkly.com
-0.0.0.0 clientstream.intuit.launchdarkly.com
 0.0.0.0 events.intuit.launchdarkly.com
 0.0.0.0 leadbolt.com
 0.0.0.0 www.leadbolt.com


### PR DESCRIPTION
Hi @lightswitch05 I'm an engineer at LaunchDarkly, and we have some reports of our customers having issues when using your block lists. I looked into it, and I see that there are some non-tracking hostnames added that are causing this.

As a brief context, LaunchDarkly is a feature flag management platform, which allows software teams to roll out new bits of code, and generally control when and how features are released to their users. SDKs embedded in our customers' applications contact our service through the `app.` and `clientstream.` hostnames to get the flag values. The SDKs then do send analytics events back to LaunchDarkly via the `events.` hostname. These analytics events are used to track how frequently flags are used, power experiments, and some other features.

It seems perfectly reasonable to me for users of your lists to block these analytics events. Doing so will not break the application your users are trying to interact with, while still protecting their privacy, and preventing their data from being used in experiments. However, blocking the `app.` and `clientstream.` hostnames will prevent the flag values from being delivered to the application, resulting in a default flag value being used (in most cases, this means the user will not get the new features).

I'd be happy to answer any questions about how we use data (and how we protect it) if you like.  
 Judging from the comment on commit 96f89e1, it seems there was a misunderstanding about the purpose of these hostnames.

Thanks!